### PR TITLE
Added PDL reference docs to sidebar

### DIFF
--- a/content/sidebar.js
+++ b/content/sidebar.js
@@ -13,6 +13,7 @@ sidebar = [
     title: 'Documentation',
     pages: [
       new PageLink('PDL Book', 'FirstSteps'),
+      new PageLink('PDL Reference Docs', 'reference'),
       new DocsLink('PDL::FAQ', 'Frequently Asked Questions'),
       new DocsLink('PDL::Tutorials'),
       new DocsLink('PDL::Modules'),


### PR DESCRIPTION
The PDL Reference Documentation is currently accessible only through the central icon (owl) in the home page but is not present in the sidebar as the other two. 