### PR TITLE
Delete old link and announcement

### DIFF
--- a/content/home.html
+++ b/content/home.html
@@ -44,7 +44,7 @@
 	</div>
 
 	<div class="news">
-	  <h3><a href="https://sourceforge.net/p/pdl/news/">Recent News</a></h3>
+	  <h3>Recent News</h3>
 	  <dl>
 
             <dt>2022-05-03</dt>
@@ -66,16 +66,6 @@
               <ul>
                   <li>memory-management bugs fixed
                   <li>msolve etc now handle native-complex
-              </ul>
-            </dd>
-
-	    <dt>2022-03-16</dt>
-	    <dd><a href="https://sourceforge.net/p/pdl/mailman/message/37626234/">Announcing</a> the release
-	      of <a href="https://metacpan.org/release/ETJ/PDL-2.077">PDL 2.077 to CPAN</a>:
-              <ul>
-                  <li>many bugfixes
-                  <li>demo system now plugin-based
-                  <li>TriD demos fixed
               </ul>
             </dd>
 


### PR DESCRIPTION
- removed link in title for "recent news" because it pointed to an outdated news list in sourceforge
- deleted announcement of PDL 2.077, newest now is 2.079

Tested locally. Works as expected.